### PR TITLE
initialize 'local_custom_counter' and 'local_toggle' to zero

### DIFF
--- a/numa-PageRank.C
+++ b/numa-PageRank.C
@@ -454,8 +454,8 @@ void *PageRankThread(void *arg) {
 
     pthread_t subTids[CORES_PER_NODE];    
 
-    volatile int local_custom_counter;
-    volatile int local_toggle;
+    volatile int local_custom_counter = 0;
+    volatile int local_toggle = 0;
 
     for (int i = 0; i < CORES_PER_NODE; i++) {	
 	PR_subworker_arg *arg = (PR_subworker_arg *)malloc(sizeof(PR_subworker_arg));


### PR DESCRIPTION
These two variable are used to construct Custom_barrier later and should be initialized to zero