### PR TITLE
skip ring when reading graph for PageRank

### DIFF
--- a/numa-PageRank-pull.C
+++ b/numa-PageRank-pull.C
@@ -452,12 +452,12 @@ int parallel_main(int argc, char* argv[]) {
     numa_set_interleave_mask(numa_all_nodes_ptr);
     if(symmetric) {
 	graph<symmetricVertex> G = 
-	    readGraph<symmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<symmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	//G.del(); 
     } else {
 	graph<asymmetricVertex> G = 
-	    readGraph<asymmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<asymmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	//G.del();
     }

--- a/numa-PageRank-write.C
+++ b/numa-PageRank-write.C
@@ -461,12 +461,12 @@ int parallel_main(int argc, char* argv[]) {
     numa_set_interleave_mask(numa_all_nodes_ptr);
     if(symmetric) {
 	graph<symmetricVertex> G = 
-	    readGraph<symmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<symmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	G.del(); 
     } else {
 	graph<asymmetricVertex> G = 
-	    readGraph<asymmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<asymmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	G.del();
     }

--- a/numa-PageRank.C
+++ b/numa-PageRank.C
@@ -633,12 +633,12 @@ int parallel_main(int argc, char* argv[]) {
     startTime();
     if(symmetric) {
 	graph<symmetricVertex> G = 
-	    readGraph<symmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<symmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	//G.del(); 
     } else {
 	graph<asymmetricVertex> G = 
-	    readGraph<asymmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<asymmetricVertex>(iFile,symmetric,binary);
 	PageRank(G, maxIter);
 	//G.del();
     }

--- a/numa-PageRankDelta.C
+++ b/numa-PageRankDelta.C
@@ -495,12 +495,12 @@ int parallel_main(int argc, char* argv[]) {
     numa_set_interleave_mask(numa_all_nodes_ptr);
     if(symmetric) {
 	graph<symmetricVertex> G = 
-	    readGraph<symmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<symmetricVertex>(iFile,symmetric,binary);
 	PageRankDelta(G);
 	G.del(); 
     } else {
 	graph<asymmetricVertex> G = 
-	    readGraph<asymmetricVertex>(iFile,symmetric,binary);
+	    readGraphSkipRing<asymmetricVertex>(iFile,symmetric,binary);
 	printf("read over\n");
 	PageRankDelta(G, maxIter);
 	G.del();


### PR DESCRIPTION
PageRank may not be run in a graph that contains self ring. This patch removes those edges when reading graph. But a little bit ugly.